### PR TITLE
Create an IServiceContext interface to address issues related to resolving instances using lambdas

### DIFF
--- a/src/BlueMilk.Testing/IoC/Acceptance/build_by_lambda.cs
+++ b/src/BlueMilk.Testing/IoC/Acceptance/build_by_lambda.cs
@@ -7,6 +7,14 @@ namespace BlueMilk.Testing.IoC.Acceptance
 {
     public class build_by_lambdas
     {
+        [Fact]
+        public void build_with_lambda_that_gets_from_context()
+        {
+            var container = new Container(x => { x.For<Rule>().Add(c => c.GetInstance<inline_dependencies.RuleBuilder>().ForColor("Beige")); });
+
+            container.GetInstance<Rule>().ShouldBeOfType<ColorRule>().Color.ShouldBe("Beige");
+        }
+
         // SAMPLE: build-with-lambdas
         [Fact]
         public void build_with_lambdas_1()

--- a/src/BlueMilk.Testing/IoC/Acceptance/build_by_lambda.cs
+++ b/src/BlueMilk.Testing/IoC/Acceptance/build_by_lambda.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Shouldly;
+using StructureMap.Testing.Widget;
+using Xunit;
+
+namespace BlueMilk.Testing.IoC.Acceptance
+{
+    public class build_by_lambdas
+    {
+        // SAMPLE: build-with-lambdas
+        [Fact]
+        public void build_with_lambdas_1()
+        {
+            var container = new Container(x =>
+                                          {
+                                              // Build by a static instance
+                                              x.For<Rule>().Add(new ColorRule("Red")).Named("Red");
+
+                                              // Build by Func<T> with a user supplied description
+                                              x.For<Rule>()
+                                               .Add(s => s.GetInstance<inline_dependencies.RuleBuilder>().ForColor("Green"))
+                                               .Named("Green");
+
+                                              // Build by Func<IBuildSession, T> with a user description
+                                              x.For<Rule>()
+                                               .Add(s => s.GetInstance<inline_dependencies.RuleBuilder>().ForColor("Purple"))
+                                               .Named("Purple");
+                                          });
+
+            container.GetInstance<Rule>("Red").ShouldBeOfType<ColorRule>().Color.ShouldBe("Red");
+            container.GetInstance<Rule>("Green").ShouldBeOfType<ColorRule>().Color.ShouldBe("Green");
+            container.GetInstance<Rule>("Purple").ShouldBeOfType<ColorRule>().Color.ShouldBe("Purple");
+        }
+
+        // ENDSAMPLE
+
+        // SAMPLE: lambdas-as-inline-dependency
+        [Fact]
+        public void as_inline_dependency()
+        {
+            var container = new Container(x =>
+                                          {
+                                              // Build by a simple Expression<Func<T>>
+                                              x.For<inline_dependencies.RuleHolder>()
+                                               .Add<inline_dependencies.RuleHolder>()
+                                               .Named("Red")
+                                               .Ctor<Rule>()
+                                               .Is(new ColorRule("Red"));
+
+                                              // Build by a simple Expression<Func<IBuildSession, T>>
+                                              x.For<inline_dependencies.RuleHolder>()
+                                               .Add<inline_dependencies.RuleHolder>()
+                                               .Named("Blue")
+                                               .Ctor<Rule>()
+                                               .Is("The Blue One", _ => { return new ColorRule("Blue"); });
+
+                                              // Build by Func<T> with a user supplied description
+                                              x.For<inline_dependencies.RuleHolder>()
+                                               .Add<inline_dependencies.RuleHolder>()
+                                               .Named("Green")
+                                               .Ctor<Rule>()
+                                               .Is("The Green One", s => s.GetInstance<inline_dependencies.RuleBuilder>().ForColor("Green"));
+
+                                              // Build by Func<IBuildSession, T> with a user description
+                                              x.For<inline_dependencies.RuleHolder>()
+                                               .Add<inline_dependencies.RuleHolder>()
+                                               .Named("Purple")
+                                               .Ctor<Rule>()
+                                               .Is("The Purple One", s => { return s.GetInstance<inline_dependencies.RuleBuilder>().ForColor("Purple"); });
+                                          });
+
+            container.GetInstance<inline_dependencies.RuleHolder>("Red").Rule.ShouldBeOfType<ColorRule>().Color.ShouldBe("Red");
+            container.GetInstance<inline_dependencies.RuleHolder>("Blue").Rule.ShouldBeOfType<ColorRule>().Color.ShouldBe("Blue");
+            container.GetInstance<inline_dependencies.RuleHolder>("Green").Rule.ShouldBeOfType<ColorRule>().Color.ShouldBe("Green");
+            container.GetInstance<inline_dependencies.RuleHolder>("Purple").Rule.ShouldBeOfType<ColorRule>().Color.ShouldBe("Purple");
+        }
+
+        // ENDSAMPLE
+    }
+}

--- a/src/BlueMilk/IContainer.cs
+++ b/src/BlueMilk/IContainer.cs
@@ -1,167 +1,16 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
-using BlueMilk.Compilation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BlueMilk
 {
-    public interface IContainer : IServiceProvider, IDisposable
+    public interface IContainer : IServiceContext, IDisposable
     {
-        /// <summary>
-        /// Suitable for building concrete types that will be resolved only a few times
-        /// to avoid the cost of having to register or build out a pre-compiled "build plan"
-        /// internally
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        T QuickBuild<T>();
-        
-        /// <summary>
-        /// Suitable for building concrete types that will be resolved only a few times
-        /// to avoid the cost of having to register or build out a pre-compiled "build plan"
-        /// internally
-        /// </summary>
-        object QuickBuild(Type objectType);
-        
-        /// <summary>
-        /// Creates or finds the default instance of <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
-        /// <returns>The default instance of <typeparamref name="T"/>.</returns>
-        T GetInstance<T>();
-
-        /// <summary>
-        /// Creates or finds the named instance of <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
-        /// <param name="name">The name of the instance.</param>
-        /// <returns>The named instance of <typeparamref name="T"/>.</returns>
-        T GetInstance<T>(string name);
-
-        /// <summary>
-        /// Creates or finds the default instance of <paramref name="serviceType"/>.
-        /// </summary>
-        /// <param name="serviceType">The type which instance is to be created or found.</param>
-        /// <returns>The default instance of <paramref name="serviceType"/>.</returns>
-        object GetInstance(Type serviceType);
-
-        /// <summary>
-        /// Creates or finds the named instance of <paramref name="serviceType"/>.
-        /// </summary>
-        /// <param name="serviceType">The type which instance is to be created or found.</param>
-        /// <param name="name">The name of the instance.</param>
-        /// <returns>The named instance of <paramref name="serviceType"/>.</returns>
-        object GetInstance(Type serviceType, string name);
-        
         /// <summary>
         /// Starts a "Nested" Container for atomic, isolated access.
         /// </summary>
         /// <returns>The created nested container.</returns>
         IContainer GetNestedContainer();
 
-        /// <summary>
-        /// Creates or resolves all registered instances of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type which instances are to be created or resolved.</typeparam>
-        /// <returns>All created or resolved instances of type <typeparamref name="T"/>.</returns>
-        IReadOnlyList<T> GetAllInstances<T>();
-
-        /// <summary>
-        /// Creates or resolves all registered instances of the <paramref name="serviceType"/>.
-        /// </summary>
-        /// <param name="serviceType">The type which instances are to be created or resolved.</param>
-        /// <returns>All created or resolved instances of type <paramref name="serviceType"/>.</returns>
-        IEnumerable GetAllInstances(Type serviceType);
-        
-        /// <summary>
-        /// Provides queryable access to the configured serviceType's and Instances of this Container.
-        /// </summary>
-        IModel Model { get; }
-        
-        /// <summary>
-        /// Govern the behavior on Dispose() to prevent applications from 
-        /// being prematurely disposed
-        /// </summary>
-        DisposalLock DisposalLock { get; set; }
-        
-                /// <summary>
-        /// Creates or finds the default instance of <typeparamref name="T"/>. Returns the default value of
-        /// <typeparamref name="T"/> if it is not known to the container.
-        /// </summary>
-        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
-        /// <returns>The default instance of <typeparamref name="T"/> if resolved; the default value of
-        /// <typeparamref name="T"/> otherwise.</returns>
-        T TryGetInstance<T>();
-
-        /// <summary>
-        /// Creates or finds the named instance of <typeparamref name="T"/>. Returns the default value of
-        /// <typeparamref name="T"/> if the named instance is not known to the container.
-        /// </summary>
-        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
-        /// <param name="name">The name of the instance.</param>
-        /// <returns>The named instance of <typeparamref name="T"/> if resolved; the default value of
-        /// <typeparamref name="T"/> otherwise.</returns>
-        T TryGetInstance<T>(string name);
-
-        /// <summary>
-        /// Creates or finds the default instance of <paramref name="serviceType"/>. Returns <see langword="null"/> if
-        /// <paramref name="serviceType"/> is not known to the container.
-        /// </summary>
-        /// <param name="serviceType">The type which instance is to be created or found.</param>
-        /// <returns>The default instance of <paramref name="serviceType"/> if resolved; <see langword="null"/> otherwise.
-        /// </returns>
-        object TryGetInstance(Type serviceType);
-
-        /// <summary>
-        /// Creates or finds the named instance of <paramref name="serviceType"/>. Returns <see langword="null"/> if
-        /// the named instance is not known to the container.
-        /// </summary>
-        /// <param name="serviceType">The type which instance is to be created or found.</param>
-        /// <param name="name">The name of the instance.</param>
-        /// <returns>The named instance of <paramref name="serviceType"/> if resolved; <see langword="null"/> otherwise.
-        /// </returns>
-        object TryGetInstance(Type serviceType, string name);
-
-
-        /// <summary>
-        /// Returns a report detailing the complete configuration of all PluginTypes and Instances
-        /// </summary>
-        /// <param name="serviceType">Optional parameter to filter the results down to just this plugin type.</param>
-        /// <param name="assembly">Optional parameter to filter the results down to only plugin types from this
-        /// <see cref="Assembly"/>.</param>
-        /// <param name="namespace">Optional parameter to filter the results down to only plugin types from this
-        /// namespace.</param>
-        /// <param name="typeName">Optional parameter to filter the results down to any plugin type whose name contains
-        ///  this text.</param>
-        /// <returns>The detailed report of the configuration.</returns>
-        string WhatDoIHave(Type serviceType = null, Assembly assembly = null, string @namespace = null,
-            string typeName = null);
-
-        /// <summary>
-        /// Returns a textual report of all the assembly scanners used to build up this Container
-        /// </summary>
-        /// <returns></returns>
-        string WhatDidIScan();
-
-
-        /// <summary>
-        /// Use BlueMilk's inline object construction inside of the generated methods
-        /// </summary>
-        /// <param name="assembly"></param>
-        void CompileWithInlineServices(GeneratedAssembly assembly);
-
-        /// <summary>
-        /// Use BlueMilk's inline object construction inside of the generated methods
-        /// </summary>
-        /// <param name="assembly"></param>
-        /// <returns></returns>
-        string GenerateCodeWithInlineServices(GeneratedAssembly assembly);
-
-        
-        
-        
         /// <summary>
         /// Use with caution!  Does a full environment test of the configuration of this container.  Will try to create
         /// every configured instance and afterward calls any methods marked with

--- a/src/BlueMilk/IServiceContext.cs
+++ b/src/BlueMilk/IServiceContext.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using BlueMilk.Compilation;
+using BlueMilk.IoC;
+using BlueMilk.Util;
+
+namespace BlueMilk
+{
+    public interface IServiceContext : IServiceProvider, IDisposable
+    {
+        PerfTimer Bootstrapping { get; }
+        Scope Root { get; }
+
+        /// <summary>
+        /// Govern the behavior on Dispose() to prevent applications from 
+        /// being prematurely disposed
+        /// </summary>
+        DisposalLock DisposalLock { get; set; }
+
+        /// <summary>
+        /// Provides queryable access to the configured serviceType's and Instances of this Container.
+        /// </summary>
+        IModel Model { get; }
+        IList<IDisposable> Disposables { get; }
+        IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
+        /// Creates or finds the default instance of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
+        /// <returns>The default instance of <typeparamref name="T"/>.</returns>
+        T GetInstance<T>();
+
+        /// <summary>
+        /// Creates or finds the named instance of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
+        /// <param name="name">The name of the instance.</param>
+        /// <returns>The named instance of <typeparamref name="T"/>.</returns>
+        T GetInstance<T>(string name);
+
+        /// <summary>
+        /// Creates or finds the default instance of <paramref name="serviceType"/>.
+        /// </summary>
+        /// <param name="serviceType">The type which instance is to be created or found.</param>
+        /// <returns>The default instance of <paramref name="serviceType"/>.</returns>
+        object GetInstance(Type serviceType);
+
+        /// <summary>
+        /// Creates or finds the named instance of <paramref name="serviceType"/>.
+        /// </summary>
+        /// <param name="serviceType">The type which instance is to be created or found.</param>
+        /// <param name="name">The name of the instance.</param>
+        /// <returns>The named instance of <paramref name="serviceType"/>.</returns>
+        object GetInstance(Type serviceType, string name);
+
+        /// <summary>
+        /// Creates or finds the default instance of <typeparamref name="T"/>. Returns the default value of
+        /// <typeparamref name="T"/> if it is not known to the container.
+        /// </summary>
+        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
+        /// <returns>The default instance of <typeparamref name="T"/> if resolved; the default value of
+        /// <typeparamref name="T"/> otherwise.</returns>
+        T TryGetInstance<T>();
+
+        /// <summary>
+        /// Creates or finds the named instance of <typeparamref name="T"/>. Returns the default value of
+        /// <typeparamref name="T"/> if the named instance is not known to the container.
+        /// </summary>
+        /// <typeparam name="T">The type which instance is to be created or found.</typeparam>
+        /// <param name="name">The name of the instance.</param>
+        /// <returns>The named instance of <typeparamref name="T"/> if resolved; the default value of
+        /// <typeparamref name="T"/> otherwise.</returns>
+        T TryGetInstance<T>(string name);
+
+        /// <summary>
+        /// Creates or finds the default instance of <paramref name="serviceType"/>. Returns <see langword="null"/> if
+        /// <paramref name="serviceType"/> is not known to the container.
+        /// </summary>
+        /// <param name="serviceType">The type which instance is to be created or found.</param>
+        /// <returns>The default instance of <paramref name="serviceType"/> if resolved; <see langword="null"/> otherwise.
+        /// </returns>
+        object TryGetInstance(Type serviceType);
+
+        /// <summary>
+        /// Creates or finds the named instance of <paramref name="serviceType"/>. Returns <see langword="null"/> if
+        /// the named instance is not known to the container.
+        /// </summary>
+        /// <param name="serviceType">The type which instance is to be created or found.</param>
+        /// <param name="name">The name of the instance.</param>
+        /// <returns>The named instance of <paramref name="serviceType"/> if resolved; <see langword="null"/> otherwise.
+        /// </returns>
+        object TryGetInstance(Type serviceType, string name);
+
+        /// <summary>
+        /// Suitable for building concrete types that will be resolved only a few times
+        /// to avoid the cost of having to register or build out a pre-compiled "build plan"
+        /// internally
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        T QuickBuild<T>();
+
+        /// <summary>
+        /// Suitable for building concrete types that will be resolved only a few times
+        /// to avoid the cost of having to register or build out a pre-compiled "build plan"
+        /// internally
+        /// </summary>
+        object QuickBuild(Type objectType);
+
+        /// <summary>
+        /// Creates or resolves all registered instances of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type which instances are to be created or resolved.</typeparam>
+        /// <returns>All created or resolved instances of type <typeparamref name="T"/>.</returns>
+        IReadOnlyList<T> GetAllInstances<T>();
+
+        /// <summary>
+        /// Creates or resolves all registered instances of the <paramref name="serviceType"/>.
+        /// </summary>
+        /// <param name="serviceType">The type which instances are to be created or resolved.</param>
+        /// <returns>All created or resolved instances of type <paramref name="serviceType"/>.</returns>
+        IEnumerable GetAllInstances(Type serviceType);
+
+        /// <summary>
+        /// Returns a report detailing the complete configuration of all PluginTypes and Instances
+        /// </summary>
+        /// <param name="serviceType">Optional parameter to filter the results down to just this plugin type.</param>
+        /// <param name="assembly">Optional parameter to filter the results down to only plugin types from this
+        /// <see cref="Assembly"/>.</param>
+        /// <param name="namespace">Optional parameter to filter the results down to only plugin types from this
+        /// namespace.</param>
+        /// <param name="typeName">Optional parameter to filter the results down to any plugin type whose name contains
+        ///  this text.</param>
+        /// <returns>The detailed report of the configuration.</returns>
+        string WhatDoIHave(Type serviceType = null, Assembly assembly = null, string @namespace = null,
+                           string typeName = null);
+
+        /// <summary>
+        /// Returns a textual report of all the assembly scanners used to build up this Container
+        /// </summary>
+        /// <returns></returns>
+        string WhatDidIScan();
+
+        /// <summary>
+        /// Use BlueMilk's inline object construction inside of the generated methods
+        /// </summary>
+        /// <param name="assembly"></param>
+        void CompileWithInlineServices(GeneratedAssembly assembly);
+
+        /// <summary>
+        /// Use BlueMilk's inline object construction inside of the generated methods
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <returns></returns>
+        string GenerateCodeWithInlineServices(GeneratedAssembly assembly);
+    }
+}

--- a/src/BlueMilk/IoC/Scope.cs
+++ b/src/BlueMilk/IoC/Scope.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using Baseline;
-using Baseline.Reflection;
 using BlueMilk.Compilation;
 using BlueMilk.IoC.Diagnostics;
 using BlueMilk.IoC.Instances;
@@ -16,7 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace BlueMilk.IoC
 {
-    public class Scope : IServiceScope, IServiceProvider, ISupportRequiredService, IServiceScopeFactory
+    public class Scope : IServiceScope, ISupportRequiredService, IServiceScopeFactory, IServiceContext
     {
         protected bool _hasDisposed;
 

--- a/src/BlueMilk/ServiceRegistry.cs
+++ b/src/BlueMilk/ServiceRegistry.cs
@@ -188,7 +188,7 @@ namespace BlueMilk
             }
 
 
-            public LambdaInstance<IContainer, T> Add(Func<IContainer, T> func) 
+            public LambdaInstance<IServiceContext, T> Add(Func<IServiceContext, T> func) 
             {
                 var instance = LambdaInstance.For(func);
 
@@ -198,7 +198,7 @@ namespace BlueMilk
 
             }
             
-            public LambdaInstance<IContainer, T> Use(Func<IContainer, T> func)
+            public LambdaInstance<IServiceContext, T> Use(Func<IServiceContext, T> func)
             {
                 return Add(func);
 


### PR DESCRIPTION
Addresses #68 by creating an `IServiceContext` interface that pulls up all of the public members of the `Scope` class and then bases the `IContainer` interface on the `IServiceContext` and using `IServiceContext` on the `ServiceRegistry.For(func)` method.

Also imports a couple of tests from StructureMap to test construction via lambdas.