### PR TITLE
Fixed an issue where the AssemblyScanner.Describe() would never repor…

### DIFF
--- a/src/BlueMilk.Testing/IoC/Diagnostics/WhatDidIScan_smoke_tests.cs
+++ b/src/BlueMilk.Testing/IoC/Diagnostics/WhatDidIScan_smoke_tests.cs
@@ -45,6 +45,46 @@ namespace BlueMilk.Testing.IoC.Diagnostics
             Console.WriteLine(container.WhatDidIScan());
             // ENDSAMPLE
         }
+
+        [Fact]
+        public void what_did_i_scan_should_list_assemblies()
+        {
+            var c = new Container(x => x.For<IWidget>().Use<ColorWidget>());
+
+
+            var container = new Container(_ =>
+                                          {
+                                              _.Scan(x =>
+                                                     {
+                                                         x.TheCallingAssembly();
+
+                                                         x.WithDefaultConventions();
+                                                         x.RegisterConcreteTypesAgainstTheFirstInterface();
+                                                         x.SingleImplementationsOfInterface();
+                                                     });
+
+                                              _.Scan(x =>
+                                                     {
+                                                         // Give your scanning operation a descriptive name
+                                                         // to help the diagnostics to be more useful
+                                                         x.Description = "Second Scanner";
+
+                                                         x.AssembliesFromApplicationBaseDirectory(assem => assem.FullName.Contains("Widget"));
+                                                         x.ConnectImplementationsToTypesClosing(typeof(IService<>));
+                                                         x.AddAllTypesOf<IWidget>();
+                                                     });
+                                          });
+
+            var whatDidIScan = container.WhatDidIScan();
+            whatDidIScan.ShouldContain("* StructureMap.Testing.GenericWidgets");
+            whatDidIScan.ShouldContain("* StructureMap.Testing.Widget");
+            whatDidIScan.ShouldContain("* StructureMap.Testing.Widget2");
+            whatDidIScan.ShouldContain("* StructureMap.Testing.Widget3");
+            whatDidIScan.ShouldContain("* StructureMap.Testing.Widget4");
+            whatDidIScan.ShouldContain("* StructureMap.Testing.Widget5");
+
+            Console.WriteLine(whatDidIScan);
+        }
     }
 
     // SAMPLE: whatdidiscan-result

--- a/src/BlueMilk/Scanning/Conventions/AssemblyScanner.cs
+++ b/src/BlueMilk/Scanning/Conventions/AssemblyScanner.cs
@@ -145,7 +145,7 @@ namespace BlueMilk.Scanning.Conventions
             writer.WriteLine("Assemblies");
             writer.WriteLine("----------");
 
-            _records.OrderBy(x => x.Name).Each(x => writer.WriteLine("* " + x));
+            _assemblies.OrderBy(x => x.FullName).Each(x => writer.WriteLine("* " + x));
             writer.WriteLine();
 
             writer.WriteLine("Conventions");


### PR DESCRIPTION
`AssemblyScanner.Describe()` would never actually report the assemblies that it scanned because it was using the `_records` field to try to list the scanned assemblies.  This field is never updated and always empty; this change uses the `_assemblies` field instead, and adds a unit test to verify that `Container.WhatDidIScan()` contains the assemblies that are actually expected.